### PR TITLE
Correctly convert Heroku API responses to JSON

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,3 @@
 class ApplicationController < ActionController::Base
-  # Prevent CSRF attacks by raising an exception.
-  # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 end

--- a/app/models/heroku_client.rb
+++ b/app/models/heroku_client.rb
@@ -6,7 +6,7 @@ class HerokuClient
 
   def create_and_deploy
     begin
-      @body = client.app_setup.create(
+      @json_body = client.app_setup.create(
         app: {
           name: app_name,
           personal: true,
@@ -16,7 +16,7 @@ class HerokuClient
         }
       )
     rescue Excon::Errors::ClientError => error
-      @body = error.response.body
+      @json_body = JSON.parse(error.response.body)
     end
   end
 
@@ -29,14 +29,10 @@ class HerokuClient
   end
 
   def error_response
-    @body
+    json_body
   end
 
   private
 
-  attr_reader :app_name, :client
-
-  def json_body
-    JSON.parse(@body)
-  end
+  attr_reader :app_name, :client, :json_body
 end

--- a/spec/support/heroku_stubs.rb
+++ b/spec/support/heroku_stubs.rb
@@ -2,13 +2,21 @@ module HerokuStubs
   def stub_app_setup(app_name)
     stub_request(:post, "https://api.heroku.com/app-setups").
       with(body: request_body(app_name)).
-      to_return(status: 201, body: app_setup_body(app_name))
+      to_return(
+        status: 201,
+        body: app_setup_body(app_name),
+        headers: { "Content-Type" => "application/json" }
+      )
   end
 
   def stub_failed_app_setup(options = {})
     stub_request(:post, "https://api.heroku.com/app-setups").
       with(body: request_body(app_name)).
-      to_return(status: 422, body: failed_app_setup_body(options))
+      to_return(
+        status: 422,
+        body: failed_app_setup_body(options),
+        headers: { "Content-Type" => "application/json" }
+      )
   end
 
   def app_setup_body(app_name)


### PR DESCRIPTION
Heroku sends back a Content-Type header indicating that it's responding with JSON. Its client reads that header and auto-converts the response body from a string of JSON to a Ruby representation.

Excon does not auto-convert to a Ruby hash, so when we catch an error and grab `error.response.body`, it's the raw JSON string.

After this change, the HerokuClient always has a `json_body` that is a Ruby representation of the JSON.
