### PR TITLE
Use random app names with a standard prefix

### DIFF
--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::AppsController < ApplicationController
   def create
-    client = create_and_deploy
+    client = create_and_deploy(app_name)
 
     if client.succeeded?
       render json: { url: client.app_url }, status: 201
@@ -11,13 +11,14 @@ class Api::V1::AppsController < ApplicationController
 
   private
 
-  def create_and_deploy
+  def create_and_deploy(app_name)
     HerokuClient.new(app_name).tap do |client|
       client.create_and_deploy
     end
   end
 
   def app_name
-    "cheetah"
+    site_id = SecureRandom.urlsafe_base64(8)
+    "shorthanded-#{site_id}"
   end
 end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -57,6 +57,12 @@ describe "POST /api/apps" do
   end
 
   def app_name
-    "cheetah"
+    id = 1
+    stub_site_id(id)
+    "shorthanded-#{id}"
+  end
+
+  def stub_site_id(id)
+    allow(SecureRandom).to receive(:urlsafe_base64).with(8).and_return(id)
   end
 end


### PR DESCRIPTION
- The standard prefix makes it easy to find them in my Heroku console
- The names don't have to be pretty since people will (eventually) be looking at a "real" URL, not the Heroku URL
