### PR TITLE
Always generate valid Heroku app names

### DIFF
--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -18,7 +18,6 @@ class Api::V1::AppsController < ApplicationController
   end
 
   def app_name
-    site_id = SecureRandom.urlsafe_base64(8)
-    "shorthanded-#{site_id}"
+    @app_name ||= HerokuAppNameGenerator.new.generate
   end
 end

--- a/app/models/heroku_app_name_generator.rb
+++ b/app/models/heroku_app_name_generator.rb
@@ -1,0 +1,20 @@
+# This class generates names for Heroku apps. They have a common prefix so
+# they're easy to find in the Heroku console.
+#
+# Heroku has the following rules about app names:
+# * Must be <30 characters long
+# * Must start with a letter
+# * Can only contain lowercase letters, numbers, and dashes
+class HerokuAppNameGenerator
+  PREFIX = "shorthanded-"
+
+  def generate
+    PREFIX + random_string
+  end
+
+  private
+
+  def random_string
+    SecureRandom.urlsafe_base64(8).downcase.gsub("_", "-")
+  end
+end

--- a/spec/models/heroku_app_name_generator_spec.rb
+++ b/spec/models/heroku_app_name_generator_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe HerokuAppNameGenerator do
+  context "#generate" do
+    it "prefixes nams with 'shorthanded-'" do
+      name = HerokuAppNameGenerator.new.generate
+
+      expect(name).to start_with "shorthanded-"
+    end
+
+    it "adds a short random string to the end" do
+      base64 = "uwm8hsgpzju"
+      stub_secure_random(base64)
+
+      name = HerokuAppNameGenerator.new.generate
+
+      expect(name).to end_with base64
+    end
+
+    it "downcases the app name" do
+      base64 = "UWm8hsgPzjU"
+      stub_secure_random(base64)
+
+      name = HerokuAppNameGenerator.new.generate
+
+      expect(name.downcase).to eq name
+    end
+
+    it "replaces underscores with hyphens" do
+      base64 = "am_pm"
+      stub_secure_random(base64)
+
+      name = HerokuAppNameGenerator.new.generate
+
+      expect(name).to end_with "am-pm"
+    end
+  end
+
+  def stub_secure_random(base64)
+    allow(SecureRandom).to receive(:urlsafe_base64).with(8).and_return(base64)
+  end
+end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -57,12 +57,13 @@ describe "POST /api/apps" do
   end
 
   def app_name
-    id = 1
-    stub_site_id(id)
-    "shorthanded-#{id}"
+    @app_name ||= stub_app_name("abcdef1234")
   end
 
-  def stub_site_id(id)
-    allow(SecureRandom).to receive(:urlsafe_base64).with(8).and_return(id)
+  def stub_app_name(id)
+    name = "shorthanded-#{id}"
+    generator = double("app name generator", generate: name)
+    allow(HerokuAppNameGenerator).to receive(:new).and_return(generator)
+    name
   end
 end


### PR DESCRIPTION
Heroku has a few rules for app names:
- Must be <30 characters long
- Must start with a letter
- Can only contain lowercase letters, numbers, and dashes
