### PR TITLE
Use a shorter prefix for generated Heroku names

### DIFF
--- a/app/models/heroku_app_name_generator.rb
+++ b/app/models/heroku_app_name_generator.rb
@@ -2,11 +2,11 @@
 # they're easy to find in the Heroku console.
 #
 # Heroku has the following rules about app names:
-# * Must be <30 characters long
+# * Must be <= 30 characters long
 # * Must start with a letter
 # * Can only contain lowercase letters, numbers, and dashes
 class HerokuAppNameGenerator
-  PREFIX = "shorthanded-"
+  PREFIX = "shorty-"
 
   def generate
     PREFIX + random_string
@@ -15,6 +15,6 @@ class HerokuAppNameGenerator
   private
 
   def random_string
-    SecureRandom.urlsafe_base64(8).downcase.gsub("_", "-")
+    SecureRandom.urlsafe_base64(15).downcase.gsub("_", "-")
   end
 end

--- a/spec/models/heroku_app_name_generator_spec.rb
+++ b/spec/models/heroku_app_name_generator_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 describe HerokuAppNameGenerator do
   context "#generate" do
-    it "prefixes nams with 'shorthanded-'" do
+    it "prefixes the name with 'shorty-'" do
       name = HerokuAppNameGenerator.new.generate
 
-      expect(name).to start_with "shorthanded-"
+      expect(name).to start_with "shorty-"
     end
 
     it "adds a short random string to the end" do
@@ -15,6 +15,12 @@ describe HerokuAppNameGenerator do
       name = HerokuAppNameGenerator.new.generate
 
       expect(name).to end_with base64
+    end
+
+    it "generates a name <= 30 characters long" do
+      name = HerokuAppNameGenerator.new.generate
+
+      expect(name.size).to be <= 30
     end
 
     it "downcases the app name" do
@@ -37,6 +43,6 @@ describe HerokuAppNameGenerator do
   end
 
   def stub_secure_random(base64)
-    allow(SecureRandom).to receive(:urlsafe_base64).with(8).and_return(base64)
+    allow(SecureRandom).to receive(:urlsafe_base64).with(15).and_return(base64)
   end
 end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -61,7 +61,7 @@ describe "POST /api/apps" do
   end
 
   def stub_app_name(id)
-    name = "shorthanded-#{id}"
+    name = HerokuAppNameGenerator::PREFIX + "-#{id}"
     generator = double("app name generator", generate: name)
     allow(HerokuAppNameGenerator).to receive(:new).and_return(generator)
     name


### PR DESCRIPTION
This lets me use a longer random string, and distinguishes the `shorty-` prefixed apps (which are generated) from the `shorthanded-` prefixed apps (which are the deployments of this app).
