### PR TITLE
Register the subdomain with Heroku

### DIFF
--- a/app/controllers/api/v1/apps_controller.rb
+++ b/app/controllers/api/v1/apps_controller.rb
@@ -2,11 +2,12 @@ class Api::V1::AppsController < ApplicationController
   def create
     heroku_client = create_and_deploy(app_name)
 
-    if heroku_client.succeeded?
+    if heroku_client.creation_succeeded?
       full_domain = register_cname(heroku_client.app_url)
+      heroku_client.add_domain(full_domain)
       render json: { url: full_domain }, status: 201
     else
-      render json: heroku_client.error_response, status: 502
+      render json: heroku_client.creation_error_response, status: 502
     end
   end
 

--- a/app/models/heroku_client.rb
+++ b/app/models/heroku_client.rb
@@ -20,7 +20,12 @@ class HerokuClient
     end
   end
 
-  def succeeded?
+  def add_domain(domain)
+    domain_without_scheme = domain.sub(%r{https?://}, "")
+    client.domain.create(app_name, hostname: domain_without_scheme)
+  end
+
+  def creation_succeeded?
     json_body.key?("created_at")
   end
 
@@ -28,7 +33,7 @@ class HerokuClient
     "https://#{app_name}.herokuapp.com"
   end
 
-  def error_response
+  def creation_error_response
     json_body
   end
 

--- a/spec/models/heroku_client_spec.rb
+++ b/spec/models/heroku_client_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe HerokuClient do
+  context "#create_and_deploy" do
+    context "when successful" do
+      it "creates a Heroku application" do
+        request_stub = stub_app_setup(app_name)
+
+        client = HerokuClient.new(app_name)
+        client.create_and_deploy
+
+        expect(request_stub).to have_been_requested
+      end
+
+      it "knows that it was successful" do
+        stub_app_setup(app_name)
+
+        client = HerokuClient.new(app_name)
+        client.create_and_deploy
+
+        expect(client.succeeded?).to eq true
+      end
+
+      context "when unsuccessful" do
+        it "can give back the response body" do
+          response = {
+            id: "foo_bar",
+            message: "Foo failed to bar"
+          }
+          stub_failed_app_setup(app_name, response)
+
+          client = HerokuClient.new(app_name)
+          client.create_and_deploy
+
+          expect(client.error_response).to eq response.stringify_keys
+        end
+      end
+    end
+  end
+
+  def app_name
+    "shorty-abc"
+  end
+end

--- a/spec/models/heroku_client_spec.rb
+++ b/spec/models/heroku_client_spec.rb
@@ -18,7 +18,7 @@ describe HerokuClient do
         client = HerokuClient.new(app_name)
         client.create_and_deploy
 
-        expect(client.succeeded?).to eq true
+        expect(client.creation_succeeded?).to eq true
       end
 
       context "when unsuccessful" do
@@ -32,13 +32,46 @@ describe HerokuClient do
           client = HerokuClient.new(app_name)
           client.create_and_deploy
 
-          expect(client.error_response).to eq response.stringify_keys
+          expect(client.creation_error_response).to eq response.stringify_keys
         end
       end
     end
   end
 
+  context "#add_domain" do
+    it "adds a domain to the app" do
+      request = stub_heroku_domain(app_name, domain)
+      client = HerokuClient.new(app_name)
+
+      client.add_domain(domain)
+
+      expect(request).to have_been_requested
+    end
+
+    it "removes http:// from the domain before adding" do
+      request = stub_heroku_domain(app_name, domain)
+      client = HerokuClient.new(app_name)
+
+      client.add_domain("http://" + domain)
+
+      expect(request).to have_been_requested
+    end
+
+    it "removes https:// from the domain before adding" do
+      request = stub_heroku_domain(app_name, domain)
+      client = HerokuClient.new(app_name)
+
+      client.add_domain("https://" + domain)
+
+      expect(request).to have_been_requested
+    end
+  end
+
   def app_name
     "shorty-abc"
+  end
+
+  def domain
+    "example.com"
   end
 end

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -25,7 +25,7 @@ describe "POST /api/apps" do
 
   context "when Heroku fails" do
     it "returns 502 (Bad Response from Upstream Server)" do
-      stub_failed_app_setup
+      stub_failed_app_setup(app_name)
 
       api_post api_apps_path
 
@@ -34,6 +34,7 @@ describe "POST /api/apps" do
 
     it "returns the Heroku error message" do
       stub_failed_app_setup(
+        app_name,
         id: "foo_bar",
         message: "Foo failed to bar"
       )

--- a/spec/requests/apps_spec.rb
+++ b/spec/requests/apps_spec.rb
@@ -4,7 +4,7 @@ describe "POST /api/apps" do
   context "when it succeeds" do
     it "responds with the URL of the new Heroku app" do
       stub_dnsimple_client
-      stub_app_setup(app_name)
+      stub_heroku(app_name)
 
       api_post api_apps_path
 
@@ -14,8 +14,8 @@ describe "POST /api/apps" do
     end
 
     it "responds with 201 Created" do
+      stub_heroku(app_name)
       stub_dnsimple_client
-      stub_app_setup(app_name)
 
       api_post api_apps_path
 
@@ -65,6 +65,11 @@ describe "POST /api/apps" do
     @app_name ||= stub_app_name("abcdef-1234")
   end
 
+  def stub_heroku(app_name)
+    stub_app_setup(app_name)
+    stub_heroku_domain(app_name, domain_for_heroku)
+  end
+
   def stub_dnsimple_client
     client = double("DnsimpleClient")
     allow(client).to receive(:register_cname).with(
@@ -76,6 +81,10 @@ describe "POST /api/apps" do
 
   def subdomain
     @subdomain ||= stub_subdomain("secret-pine")
+  end
+
+  def domain_for_heroku
+    "#{subdomain}.#{ENV.fetch("DNSIMPLE_DOMAIN")}"
   end
 
   def stub_subdomain(name)

--- a/spec/support/heroku_stubs.rb
+++ b/spec/support/heroku_stubs.rb
@@ -1,6 +1,18 @@
 module HerokuStubs
+  BASE_URL = "https://api.heroku.com"
+
+  def stub_heroku_domain(app_name, domain)
+    stub_request(:post, api_url("/apps/#{app_name}/domains")).
+      with(body: domain_request_body(domain)).
+      to_return(
+        status: 201,
+        body: domain_response_body(domain),
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
   def stub_app_setup(app_name)
-    stub_request(:post, "https://api.heroku.com/app-setups").
+    stub_request(:post, api_url("/app-setups")).
       with(body: request_body(app_name)).
       to_return(
         status: 201,
@@ -10,7 +22,7 @@ module HerokuStubs
   end
 
   def stub_failed_app_setup(app_name, options = {})
-    stub_request(:post, "https://api.heroku.com/app-setups").
+    stub_request(:post, api_url("/app-setups")).
       with(body: request_body(app_name)).
       to_return(
         status: 422,
@@ -60,6 +72,23 @@ module HerokuStubs
         url: ENV.fetch("URL_OF_TAR_GZ_TO_DEPLOY"),
       }
     }.to_json
+  end
+
+  def domain_request_body(domain)
+    { hostname: domain }.to_json
+  end
+
+  def domain_response_body(domain)
+    {
+      created_at: "2012-01-01T12:00:00Z",
+      hostname: domain,
+      id: "01234567-89ab-cdef-0123-456789abcdef",
+      updated_at: "2012-01-01T12:00:00Z"
+    }.to_json
+  end
+
+  def api_url(path)
+    BASE_URL + path
   end
 end
 

--- a/spec/support/heroku_stubs.rb
+++ b/spec/support/heroku_stubs.rb
@@ -9,7 +9,7 @@ module HerokuStubs
       )
   end
 
-  def stub_failed_app_setup(options = {})
+  def stub_failed_app_setup(app_name, options = {})
     stub_request(:post, "https://api.heroku.com/app-setups").
       with(body: request_body(app_name)).
       to_return(
@@ -64,5 +64,5 @@ module HerokuStubs
 end
 
 RSpec.configure do |config|
-  config.include HerokuStubs, type: :request
+  config.include HerokuStubs
 end


### PR DESCRIPTION
We must tell Heroku about an external domain pointing to a Heroku app, because if Heroku doesn't know about it, it (rightly) displays an error page when it receives a request "through" that external domain.

This PR also adds specs for `HerokuClient`. Just testing it through request specs is too far removed from the actual class and makes it hard to test unhappy paths.
