### PR TITLE
Handle when DNSimple fails to register the CNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Status code: 201 Created
 
 Status code: 502 Bad Gateway
 
-Failure is directly from Heroku's create action, because that's the only thing
-that should fail, and even that is unlikely, but here's an example:
+Failure is directly from Heroku or DNSimple, depending on which failed.
+
+Example Heroku response:
 
 ```json
 {
@@ -71,7 +72,13 @@ that should fail, and even that is unlikely, but here's an example:
 }
 ```
 
-The `id` and `message` keys should always be present.
+Example DNSimple response:
+
+```json
+{
+  "message": "CNAME hello.yourdomain.com already exists so it was ignored."
+}
+```
 
 ## OK, how do I deploy this?
 

--- a/app/models/dnsimple_client.rb
+++ b/app/models/dnsimple_client.rb
@@ -5,6 +5,8 @@ class DnsimpleClient
     )
   end
 
+  attr_reader :full_domain
+
   def register_cname(subdomain, url)
     record_attributes = {
       content: url.sub(%r{https?://}, ""),
@@ -15,11 +17,21 @@ class DnsimpleClient
 
     begin
       client.domains.create_record(domain_name, record_attributes)
-      "http://#{subdomain}.#{domain_name}"
+      @succeeded = true
+      @full_domain = "http://#{subdomain}.#{domain_name}"
     rescue Dnsimple::RequestError => error
       Rails.logger.error("[DNSIMPLE CLIENT] " + error.response.body)
-      false
+      @error_response = JSON.parse(error.response.body)
+      @succeeded = false
     end
+  end
+
+  def creation_error_response
+    @error_response
+  end
+
+  def cname_registration_succeeded?
+    @succeeded
   end
 
   private

--- a/spec/models/dnsimple_client_spec.rb
+++ b/spec/models/dnsimple_client_spec.rb
@@ -3,93 +3,72 @@ require "rails_helper"
 describe DnsimpleClient do
   context "#register_cname" do
     it "registers a CNAME record for a subdomain to a given URL" do
-      stub_dnsimple_request("sub", "asdf.com")
+      request_stub = stub_successful_cname_registration("sub", "asdf.com")
       client = DnsimpleClient.new
 
-      result = client.register_cname("sub", "asdf.com")
+      client.register_cname("sub", "asdf.com")
 
-      expect(result).to eq "http://sub.#{domain_name}"
+      expect(request_stub).to have_been_requested
     end
 
     it "strips http:// from the given URL" do
-      stub_dnsimple_request("sub", "asdf.com")
+      request_stub = stub_successful_cname_registration("sub", "asdf.com")
       client = DnsimpleClient.new
 
-      result = client.register_cname("sub", "http://asdf.com")
+      client.register_cname("sub", "http://asdf.com")
 
-      expect(result).to eq "http://sub.#{domain_name}"
+      expect(request_stub).to have_been_requested
     end
 
     it "strips https:// from the target URL" do
-      stub_dnsimple_request("sub", "asdf.com")
+      request_stub = stub_successful_cname_registration("sub", "asdf.com")
       client = DnsimpleClient.new
 
-      result = client.register_cname("sub", "https://asdf.com")
+      client.register_cname("sub", "https://asdf.com")
 
-      expect(result).to eq "http://sub.#{domain_name}"
+      expect(request_stub).to have_been_requested
     end
 
     it "logs the response body if there is an error" do
       allow(Rails.logger).to receive(:error)
-      stub_failed_dnsimple_request("sub", "asdf.com", 403)
+      stub_failed_cname_registration("sub", "asdf.com", "oops")
       client = DnsimpleClient.new
 
-      result = client.register_cname("sub", "https://asdf.com")
+      client.register_cname("sub", "https://asdf.com")
 
       expect(Rails.logger).to have_received(:error).
-        with("[DNSIMPLE CLIENT] " + domain_response("sub", "asdf.com"))
-      expect(result).to eq false
+        with(/\A\[DNSIMPLE CLIENT\] /)
     end
   end
 
-  def domain_name
-    ENV.fetch("DNSIMPLE_DOMAIN")
+  context "#cname_registration_succeeded?" do
+    it "is true when the registration succeeds" do
+      stub_successful_cname_registration("sub", "asdf.com")
+      client = DnsimpleClient.new
+
+      client.register_cname("sub", "https://asdf.com")
+
+      expect(client.cname_registration_succeeded?).to eq true
+    end
+
+    it "is false when the registration succeeds" do
+      stub_failed_cname_registration("sub", "asdf.com")
+      client = DnsimpleClient.new
+
+      client.register_cname("sub", "https://asdf.com")
+
+      expect(client.cname_registration_succeeded?).to eq false
+    end
   end
 
-  def stub_dnsimple_request(subdomain, url)
-    stub_base_request(url, subdomain).
-      to_return(status: 200, body: domain_response(subdomain, url))
-  end
+  context "#creation_error_response" do
+    it "is the full JSON body returned from DNSimple on error" do
+      stub_failed_cname_registration("sub", "asdf.com", "oops")
+      client = DnsimpleClient.new
 
-  def stub_failed_dnsimple_request(subdomain, url, status_code)
-    stub_base_request(url, subdomain).
-      to_return(status: status_code, body: domain_response(subdomain, url))
-  end
+      client.register_cname("sub", "https://asdf.com")
 
-  def stub_base_request(url, subdomain)
-    params = {
-      record: {
-        content: url,
-        name: subdomain,
-        record_type: "CNAME",
-        ttl: 3600
-      }
-    }.to_param
-
-    stub_request(:post, "https://api.dnsimple.com/v1/domains/#{domain_name}/records").
-      with(
-        body: CGI.unescape(params),
-        headers: {
-          "Accept" => "application/json",
-          "User-Agent" => "dnsimple-ruby/2.0.0.alpha5",
-          "X-Dnsimple-Domain-Token" => ENV.fetch("DNSIMPLE_DOMAIN_TOKEN")
-        }
-      )
-  end
-
-  def domain_response(subdomain, url)
-    {
-      record: {
-        content: url,
-        created_at: "2013-01-29T14:25:38Z",
-        domain_id: 28,
-        id: 172,
-        name: subdomain,
-        prio: 10,
-        record_type: "CNAME",
-        ttl: 3600,
-        updated_at: "2013-01-29T14:25:38Z"
-      }
-    }.to_json
+      expect(client.creation_error_response).to eq("message" => "oops")
+    end
   end
 end

--- a/spec/support/dnsimple_stubs.rb
+++ b/spec/support/dnsimple_stubs.rb
@@ -1,0 +1,79 @@
+module DnsimpleStubs
+  BASE_URL = "https://api.dnsimple.com/v1"
+
+  def stub_successful_cname_registration(app_name, subdomain)
+    stub_cname_registration_request(app_name, subdomain).
+      to_return(
+        status: 201,
+        body: dnsimple_response_body(app_name, subdomain),
+      )
+  end
+
+  def stub_failed_cname_registration(app_name, subdomain)
+    stub_cname_registration_request(app_name, subdomain).
+      to_return(
+        status: 400,
+        body: failed_dnsimple_response_body(subdomain),
+      )
+  end
+
+  def stub_cname_registration_request(app_name, subdomain)
+    stub_request(:post, dnsimple_api_url("/records")).
+      with(
+        body: dnsimple_request_body(app_name, subdomain),
+        headers: dnsimple_headers
+    )
+  end
+
+  def failed_dnsimple_response_body(subdomain)
+    domain = "#{subdomain}.#{ENV.fetch("DNSIMPLE_DOMAIN")}"
+    {
+      message: "CNAME #{domain} already exists so it was ignored."
+    }.to_json
+  end
+
+  def dnsimple_api_url(path)
+    domain = ENV.fetch("DNSIMPLE_DOMAIN")
+    BASE_URL + "/domains/#{domain}" + path
+  end
+
+  def dnsimple_request_body(app_name, subdomain)
+    to_param = {
+      record: {
+        content: "#{app_name}.herokuapp.com",
+        name: subdomain,
+        record_type: "CNAME",
+        ttl: 3600
+      }
+    }.to_param
+    CGI.unescape(to_param)
+  end
+
+  def dnsimple_response_body(app_name, subdomain)
+    {
+      record: {
+        content: "#{app_name}.herokuapp.com",
+        created_at: Time.now.iso8601,
+        domain_id: 28,
+        id: 172,
+        name: subdomain,
+        prio: 10,
+        record_type: "CNAME",
+        ttl: 3600,
+        updated_at: Time.now.iso8601,
+      }
+    }.to_json
+  end
+
+  def dnsimple_headers
+    {
+      "Accept" => "application/json",
+      "User-Agent" => "dnsimple-ruby/2.0.0.alpha5",
+      "X-Dnsimple-Domain-Token" => ENV.fetch("DNSIMPLE_DOMAIN_TOKEN")
+    }
+  end
+end
+
+RSpec.configure do |config|
+  config.include DnsimpleStubs
+end

--- a/spec/support/dnsimple_stubs.rb
+++ b/spec/support/dnsimple_stubs.rb
@@ -1,34 +1,33 @@
 module DnsimpleStubs
   BASE_URL = "https://api.dnsimple.com/v1"
 
-  def stub_successful_cname_registration(app_name, subdomain)
-    stub_cname_registration_request(app_name, subdomain).
+  def stub_successful_cname_registration(subdomain, url)
+    stub_cname_registration_request(subdomain, url).
       to_return(
         status: 201,
-        body: dnsimple_response_body(app_name, subdomain),
+        body: dnsimple_response_body(subdomain, url),
       )
   end
 
-  def stub_failed_cname_registration(app_name, subdomain)
-    stub_cname_registration_request(app_name, subdomain).
+  def stub_failed_cname_registration(subdomain, url, message = "oops")
+    stub_cname_registration_request(subdomain, url).
       to_return(
         status: 400,
-        body: failed_dnsimple_response_body(subdomain),
+        body: failed_dnsimple_response_body(message),
       )
   end
 
-  def stub_cname_registration_request(app_name, subdomain)
+  def stub_cname_registration_request(subdomain, url)
     stub_request(:post, dnsimple_api_url("/records")).
       with(
-        body: dnsimple_request_body(app_name, subdomain),
+        body: dnsimple_request_body(subdomain, url),
         headers: dnsimple_headers
     )
   end
 
-  def failed_dnsimple_response_body(subdomain)
-    domain = "#{subdomain}.#{ENV.fetch("DNSIMPLE_DOMAIN")}"
+  def failed_dnsimple_response_body(message)
     {
-      message: "CNAME #{domain} already exists so it was ignored."
+      message: message
     }.to_json
   end
 
@@ -37,10 +36,10 @@ module DnsimpleStubs
     BASE_URL + "/domains/#{domain}" + path
   end
 
-  def dnsimple_request_body(app_name, subdomain)
+  def dnsimple_request_body(subdomain, url)
     to_param = {
       record: {
-        content: "#{app_name}.herokuapp.com",
+        content: url,
         name: subdomain,
         record_type: "CNAME",
         ttl: 3600
@@ -49,10 +48,10 @@ module DnsimpleStubs
     CGI.unescape(to_param)
   end
 
-  def dnsimple_response_body(app_name, subdomain)
+  def dnsimple_response_body(subdomain, url)
     {
       record: {
-        content: "#{app_name}.herokuapp.com",
+        content: url,
         created_at: Time.now.iso8601,
         domain_id: 28,
         id: 172,


### PR DESCRIPTION
DNSimple will fail when a CNAME record already exists for a subdomain.
